### PR TITLE
curlhttpsrc: deadlock in multi-instance scenario

### DIFF
--- a/src/gstcurlhttpsrc.c
+++ b/src/gstcurlhttpsrc.c
@@ -1642,8 +1642,10 @@ gst_curl_http_src_curl_multi_loop (gpointer thread_data)
         gst_curl_http_src_remove_queue_item (&context->queue, qelement->p);
         g_mutex_unlock (&qelement->p->buffer_mutex);
       }
+      qelement = qelement->next;
     }
     context->request_removal_element = NULL;
+    context->state = GSTCURL_MULTI_LOOP_STATE_RUNNING;
     g_mutex_unlock (&context->mutex);
   } else {
     GSTCURL_WARNING_PRINT ("Curl Loop State was invalid or unsupported");


### PR DESCRIPTION
1. fix queue iterator issue;
2. set context state to GSTCURL_MULTI_LOOP_STATE_RUNNING in case other instance is under running.

https://bugzilla.gnome.org/show_bug.cgi?id=793863